### PR TITLE
Inspector decision, early screens

### DIFF
--- a/app/views/includes/appeal-content/lpa-has-appeal-meta.html
+++ b/app/views/includes/appeal-content/lpa-has-appeal-meta.html
@@ -7,13 +7,18 @@
     padding-top: .2rem;
     padding-bottom: 0;
   }
-  /* Give some space for the tag being inline now */
-  .app-task-list__section {
-    padding-right: 140px
-  }
 </style>
 
-<dl class="govuk-summary-list appeal-details govuk-summary-list--no-border">
+<dl class="govuk-summary-list appeal-details govuk-summary-list--no-border govuk-!-margin-top-6">
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Appeal reference
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">2110166</p>
+    </dd>
+  </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       Appeal type
@@ -24,18 +29,30 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Appeal site
+      Planning authority
     </dt>
     <dd class="govuk-summary-list__value">
-      21 Cheers Drive, Speedwell, Bristol BS5 7FQ
+      <p class="govuk-body">
+        Bristol City Council
+      </p>
     </dd>
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
+      Appeal site
+    </dt>
+    <dd class="govuk-summary-list__value">
+      2 Aubrey House, Aubrey Road, BS3 3EX
+    </dd>
+  </div>
+
+
+  <!-- <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
       Application number
     </dt>
     <dd class="govuk-summary-list__value">
-      21/04125/FUL
+      23/04125/FUL
     </dd>
-  </div>
+  </div> -->
 </dl>

--- a/app/views/projects/issue-decision/v1/_routes.js
+++ b/app/views/projects/issue-decision/v1/_routes.js
@@ -1,0 +1,26 @@
+const govukPrototypeKit = require('govuk-prototype-kit')
+const router = govukPrototypeKit.requests.setupRouter()
+
+router.get('*', function(req, res, next){
+  // Change the service name for this feature
+  res.locals['serviceName'] = 'Manage your appeals'
+
+  next()
+})
+
+
+router.post('/decision-date', function (req, res) {
+  res.redirect('upload-decision')
+})
+
+router.post('/upload-decision', function (req, res) {
+  res.redirect('check-your-answers')
+})
+
+router.post('/check-your-answers', function (req, res) {
+  res.redirect('confirmation')
+})
+
+
+// Add your routes above the module.exports line
+module.exports = router

--- a/app/views/projects/issue-decision/v1/check-your-answers.html
+++ b/app/views/projects/issue-decision/v1/check-your-answers.html
@@ -1,0 +1,86 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Decision date" %}
+
+{% set title = "Check your answers" %}
+
+{% block questions %}
+
+  {% include "/includes/appeal-content/lpa-has-appeal-meta.html" %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  <h1 class="govuk-heading-l">
+    {{ title }}
+  </h1>
+
+  {{ govukSummaryList({
+    classes: 'govuk-!-margin-bottom-9',
+    rows: [
+      {
+        key: {
+          text: "Decision"
+        },
+        value: {
+          text: "Allowed"
+        },
+        actions: {
+          items: [
+            {
+              href: "#",
+              text: "Change",
+              visuallyHiddenText: " decision"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Decision date"
+        },
+        value: {
+          html: 1 | daysAgo
+        },
+        actions: {
+          items: [
+            {
+              href: "#",
+              text: "Change",
+              visuallyHiddenText: " decision date"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Decision letter"
+        },
+        value: {
+          html: "<a href='#' class='govuk-link'>4012345-planning-appeal-decision.doc</a>"
+        },
+        actions: {
+          items: [
+            {
+              href: "#",
+              text: "Change",
+              visuallyHiddenText: " decision letter"
+            }
+          ]
+        }
+      }
+    ]
+  }) }}
+
+{% endblock %}
+
+{% block buttons %}
+
+  {{ govukWarningText({
+    text: "You are about to send the decision and close the appeal. Please make sure you have reviewed the decision information",
+    iconFallbackText: "Warning"
+  }) }}
+
+	{{ govukButton({
+		text: 'Submit this decision'
+	}) }}
+
+{% endblock %}

--- a/app/views/projects/issue-decision/v1/confirmation.html
+++ b/app/views/projects/issue-decision/v1/confirmation.html
@@ -1,0 +1,41 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Decision date" %}
+
+{% set title = "Check your answers" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukPanel({
+      titleText: "Decision sent",
+      html: "Appeal reference<br><strong>2110166</strong>"
+    }) }}
+
+    <p class="govuk-body">We have sent the decision to the relevant appeal parties.</p>
+
+    <h2 class="govuk-heading-m">
+      What happens next
+    </h2>
+
+    <p class="govuk-body">
+      The appeal will be closed.
+    </p>
+
+    <p class="govuk-body">
+      <a href='#' class='govuk-link'>
+        Back to the National list
+      </a>
+    </p>
+
+    <!-- <p class="govuk-body">
+      <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+    </p> -->
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/issue-decision/v1/decision-date.html
+++ b/app/views/projects/issue-decision/v1/decision-date.html
@@ -1,0 +1,27 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Decision date" %}
+
+{% set title = "What was the decision date?" %}
+
+{% block questions %}
+
+  {% include "/includes/appeal-content/lpa-has-appeal-meta.html" %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  {{ govukDateInput({
+    id: "passport-issued",
+    namePrefix: "passport-issued",
+    fieldset: {
+      legend: {
+        text: title,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
+    hint: {
+      html: "For example, 13 9 2023"
+    }
+  }) }}
+
+{% endblock %}

--- a/app/views/projects/issue-decision/v1/includes/national-list-table.html
+++ b/app/views/projects/issue-decision/v1/includes/national-list-table.html
@@ -1,0 +1,63 @@
+<table class="govuk-table">
+<!-- <caption class="govuk-table__caption govuk-table__caption--s">All cases:</caption> -->
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+  <th scope="col" class="govuk-table__header">Appeal ID</th>
+  <th scope="col" class="govuk-table__header">Site address</th>
+  <th scope="col" class="govuk-table__header">Local planning authority</th>
+  <th scope="col" class="govuk-table__header">Appeal type</th>
+  <th scope="col" class="govuk-table__header">Status</th>
+</tr>
+</thead>
+<tbody class="govuk-table__body">
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">2110166</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">2110167</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">LPA questionnaire</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">2110168</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange">Statement review</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="#">1234560</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">1234561</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Arrange site visit</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">1234562</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">1234563</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
+</tr>
+</tbody>
+</table>

--- a/app/views/projects/issue-decision/v1/includes/personal-list-table-status-action.html
+++ b/app/views/projects/issue-decision/v1/includes/personal-list-table-status-action.html
@@ -1,0 +1,64 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Appeal ID</th>
+      <th scope="col" class="govuk-table__header">Case status</th>
+      <th scope="col" class="govuk-table__header">Document status</th>
+      <th scope="col" class="govuk-table__header">Due by</th>
+      <th scope="col" class="govuk-table__header">Action</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110166</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+      <td class="govuk-table__cell">Appellant case<br>Valid</td>
+      <td class="govuk-table__cell">10 July 2023</td>
+      <td class="govuk-table__cell"><a href="#">View</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110167</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">LPA questionnaire</strong></td>
+      <td class="govuk-table__cell">LPA questionnaire<br>Recieved</td>
+      <td class="govuk-table__cell">11 July 2023</td>
+      <td class="govuk-table__cell"><a href="#">Review</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110168</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange">Statement review</strong></td>
+      <td class="govuk-table__cell">Statements<br>Not received</td>
+      <td class="govuk-table__cell">12 July 2023</td>
+      <td class="govuk-table__cell"><a href="#"></a></td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="#">1234560</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
+      <td class="govuk-table__cell">IP comments/final comments<br>Recieved</td>
+      <td class="govuk-table__cell">13 July 2023</td>
+      <td class="govuk-table__cell"><a href="#">View</a></td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234562</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234561</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Arrange site visit</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234563</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/projects/issue-decision/v1/includes/personal-list-table-status.html
+++ b/app/views/projects/issue-decision/v1/includes/personal-list-table-status.html
@@ -1,0 +1,56 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Appeal ID</th>
+      <th scope="col" class="govuk-table__header">Case status</th>
+      <th scope="col" class="govuk-table__header">Document status</th>
+      <th scope="col" class="govuk-table__header">Due by</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110166</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+      <td class="govuk-table__cell">Appellant case<br>Valid</td>
+      <td class="govuk-table__cell">10 July 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110167</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">LPA questionnaire</strong></td>
+      <td class="govuk-table__cell">LPA questionnaire<br>Incomplete</td>
+      <td class="govuk-table__cell">11 July 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110168</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange">Statement review</strong></td>
+      <td class="govuk-table__cell">Statements<br>Not received</td>
+      <td class="govuk-table__cell">12 July 2023</td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="#">1234560</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
+      <td class="govuk-table__cell">IP comments/final comments<br>Incomplete</td>
+      <td class="govuk-table__cell">13 July 2023</td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234562</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234561</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Arrange site visit</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234563</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/projects/issue-decision/v1/includes/personal-list-table.html
+++ b/app/views/projects/issue-decision/v1/includes/personal-list-table.html
@@ -1,0 +1,56 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Appeal ID</th>
+      <th scope="col" class="govuk-table__header">Status</th>
+      <th scope="col" class="govuk-table__header">Action required</th>
+      <th scope="col" class="govuk-table__header">Due by</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110166</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+      <td class="govuk-table__cell">Appellant case <br>Valid<br><a href="#">View</a></td>
+      <td class="govuk-table__cell">10 July 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110167</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">LPA questionnaire</strong></td>
+      <td class="govuk-table__cell">LPA Questionnaire <br>Received<br><a href="#">Review</a></td>
+      <td class="govuk-table__cell">11 July 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110168</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange">Statement review</strong></td>
+      <td class="govuk-table__cell">Not received</td>
+      <td class="govuk-table__cell">12 July 2023</td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="#">1234560</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
+      <td class="govuk-table__cell">IP comments/final comments<br>Received<br><a href="#">Review</a></td>
+      <td class="govuk-table__cell">13 July 2023</td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234562</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234561</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Arrange site visit</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234563</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/projects/issue-decision/v1/upload-decision.html
+++ b/app/views/projects/issue-decision/v1/upload-decision.html
@@ -1,0 +1,101 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName = "Decision date" %}
+
+{% set title = "Upload the decision letter" %}
+
+{% block questions %}
+
+  {% include "/includes/appeal-content/lpa-has-appeal-meta.html" %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  <h1 class="govuk-heading-l">
+    {{ title }}
+  </h1>
+
+  <!-- <p class="govuk-body">
+    Before uploading your decision check the following things on the letter:
+  </p> -->
+
+  <section class="govuk-!-margin-bottom-6">
+
+    {{ govukWarningText({
+      text: "Before uploading the decision letter check the following things:",
+      iconFallbackText: "Warning"
+    }) }}
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        you have used the correct appeal reference
+      </li>
+      <li>
+        you have added the decision and visit dates
+      </li>
+      <li>
+        you have added the correct site address
+      </li>
+      <li>
+        the decision at the top and bottom of the letter
+      </li>
+      <li>
+        your signature
+      </li>
+    </ul>
+  </section>
+
+  {% set uploadHtml %}
+    {{ govukFileUpload({
+      id: 'letters-upload',
+      name: 'letters-upload',
+      classes: 'moj-multi-file-upload__input',
+      label: {
+        text: 'Upload a file',
+        classes: 'govuk-label--m'
+      },
+      hint: {
+        text: 'The file must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than 15MB'
+      }
+    }) }}
+
+    {{govukButton({
+      text: 'Upload file',
+      classes: 'govuk-button--secondary moj-multi-file-upload__button'
+    })}}
+  {% endset %}
+
+  {{ mojMultiFileUpload({
+    uploadedFiles: {
+      heading: { text: 'File added' },
+      items: []
+    },
+    uploadHtml: uploadHtml
+  }) }}
+{% endblock %}
+
+{% block pageScripts %}
+  <script>
+    // Hacky hacky single file
+    $('.moj-multi-file-upload__dropzone .govuk-body').text('Drag and drop a file here or ')
+    $('.moj-multi-file-upload__dropzone .govuk-button').text('Select file')
+    $('.moj-multi-file__uploaded-files').on('fileAdded', function() {
+      $('.moj-multi-file-upload__upload').hide()
+    });
+
+    $('.moj-multi-file__uploaded-files').click(function() {
+      $('.moj-multi-file-upload__upload').show()
+    });
+
+
+
+    // I really should learn how the MOJ upload works, however, a hack to get all the files passed into data
+    $('form').submit(function(e) {
+      e.preventDefault();
+
+      $('.moj-multi-file-upload__filename').each(function() {
+        $('<input name="letters-upload" type="checkbox" value="'+ $(this).text() +'" checked="true" style="display: none">').insertBefore('.govuk-heading-l');
+      });
+
+      $(this).unbind('submit').submit();
+    })
+  </script>
+{% endblock %}

--- a/app/views/projects/personal-list/v1/case.html
+++ b/app/views/projects/personal-list/v1/case.html
@@ -21,12 +21,27 @@
     	<span class="govuk-caption-l">Appeal 2110166</span>
     	<h1 class="govuk-heading-l">Case details</h1>
 
-      {{ govukTag({
-        text: "Ready to start",
-        classes: "govuk-tag--green"
-      })}}
+      {% if data['status'] == 'determination' %}
 
-    	{{ govukSummaryList({
+        {{ govukTag({
+          text: "Issue determination",
+          classes: "govuk-tag--pink"
+        })}}
+
+      {% else %}
+
+        {{ govukTag({
+          text: "Ready to start",
+          classes: "govuk-tag--green"
+        })}}
+
+      {% endif %}
+
+
+      {% include "/includes/appeal-content/lpa-has-appeal-meta.html" %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    	<!-- {{ govukSummaryList({
     	  classes: 'govuk-summary-list--no-border govuk-!-margin-top-6',
     	  rows: [
     	    {
@@ -46,7 +61,7 @@
     	      }
     	    }
     	  ]
-    	}) }}
+    	}) }} -->
 
       <div class="govuk-accordion govuk-!-margin-top-9" data-module="govuk-accordion" id="accordion-default">
         <div class="govuk-accordion__section">
@@ -112,6 +127,49 @@
 
     </div>
   </div>
+
+  {% if data['status'] == 'determination' %}
+
+    <form action="" method="post" class="govuk-!-margin-top-6" novalidate>
+
+      <!-- this form is branching using https://github.com/abbott567/radio-button-redirect for simpler routing-->
+
+        {{ govukRadios({
+          name: "issue-decision",
+          fieldset: {
+            legend: {
+              text: "Issue your decision",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "allowed~../../issue-decision/v1/decision-date",
+              text: "Allowed"
+            },
+            {
+              value: "dismissed~../../issue-decision/v1/decision-date",
+              text: "Dismissed"
+            },
+            {
+              value: "split~../../issue-decision/v1/decision-date",
+              text: "Split-decision"
+            },
+            {
+              value: "invalid~../../issue-decision/v1/decision-date",
+              text: "Invalid"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+    </form>
+
+  {% endif %}
 
 
 {% endblock %}


### PR DESCRIPTION
First pass at the screens for Inspector decisions, some work to do.

In this work I made a change to the appeal meta data (TBD).

Questions remain about the use of the caption and H1s, showing the meta data throughout and whether the final screen is a green confirmation screen or returning to the list of appeals with a notification banner.

For the final step before issuing I think we could add a checkbox to reduce the chance that Inspectors will send decisions in error.

Design review for this work tomorrow.