### PR TITLE
Inspector decisions, routing and invalid case

### DIFF
--- a/app/views/projects/issue-decision/v2/_routes.js
+++ b/app/views/projects/issue-decision/v2/_routes.js
@@ -8,8 +8,8 @@ router.get('*', function(req, res, next){
   next()
 })
 
-router.post('/decision', function (req, res) {
-  res.redirect('upload-decision')
+router.post('/invalid', function (req, res) {
+  res.redirect('case?status=incomplete')
 })
 
 router.post('/upload-decision', function (req, res) {

--- a/app/views/projects/issue-decision/v2/case.html
+++ b/app/views/projects/issue-decision/v2/case.html
@@ -15,14 +15,33 @@
   <div class="govuk-grid-column-two-thirds">
 
 	{% set html %}
-	  <p class="govuk-notification-banner__heading">
-	    The appeal is ready for determination
-	  </p>
-	  <p>
-      <a class="govuk-notification-banner__link" href="decision.html">
-        Issue a determination
-      </a>
-    </p>
+
+    {% if data['status'] == 'determination' %}
+  	  <p class="govuk-notification-banner__heading">
+  	    The appeal is ready for determination
+  	  </p>
+  	  <p>
+        <a class="govuk-notification-banner__link" href="decision.html">
+          Issue a determination
+        </a>
+      </p>
+    {% elif data['status'] == 'incomplete' %}
+
+        <p class="govuk-notification-banner__heading">
+          The appeal is invalid
+        </p>
+      {% if data['missing-evidence__reasons'] == 'Missing evidence' %}
+        <p>
+          Missing evidence: {{ data['missing-evidence__detail'] }}
+        </p>
+      {% else %}
+        <p>
+          Inspector notes: {{ data['other__detail'] }}
+        </p>
+      {% endif %}
+
+    {% endif %}
+
 	{% endset %}
 
 	{{ govukNotificationBanner({
@@ -72,6 +91,13 @@
     {{ govukTag({
       text: "Issue determination",
       classes: "govuk-tag--pink"
+    })}}
+
+  {% elif data['status'] == 'incomplete' %}
+
+    {{ govukTag({
+      text: "Incomplete",
+      classes: "govuk-tag--red"
     })}}
 
   {% else %}

--- a/app/views/projects/issue-decision/v2/check-your-answers.html
+++ b/app/views/projects/issue-decision/v2/check-your-answers.html
@@ -35,7 +35,7 @@
           text: "Decision"
         },
         value: {
-          text: "Allowed"
+          text: data['issued-decision'] or 'Allowed'
         },
         actions: {
           items: [

--- a/app/views/projects/issue-decision/v2/decision.html
+++ b/app/views/projects/issue-decision/v2/decision.html
@@ -28,7 +28,7 @@
 <div class="govuk-grid-column-two-thirds">
 
   {{ govukRadios({
-    name: "issue-decision",
+    name: "issued-decision",
     fieldset: {
       legend: {
         text: "Issue your decision",
@@ -38,19 +38,19 @@
     },
     items: [
       {
-        value: "allowed~upload-decision",
+        value: "Allowed~upload-decision",
         text: "Allowed"
       },
       {
-        value: "dismissed~upload-decision",
+        value: "Dismissed~upload-decision",
         text: "Dismissed"
       },
       {
-        value: "split~upload-decision",
+        value: "Split-decision~upload-decision",
         text: "Split-decision"
       },
       {
-        value: "invalid~upload-decision",
+        value: "Invalid~invalid",
         text: "Invalid"
       }
     ]

--- a/app/views/projects/issue-decision/v2/invalid.html
+++ b/app/views/projects/issue-decision/v2/invalid.html
@@ -1,0 +1,102 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Reasons the appeal is invalid" %}
+
+{% set title = "Why is the appeal invalid?" %}
+
+{% block questions %}
+
+  <span class="govuk-caption-l">
+    Appeal 2110166
+  </span>
+  <h1 class="govuk-heading-l">
+    {{ title }}
+  </h1>
+
+  <!-- <p class="govuk-body">
+    You need to tell inspectors how to prepare for a site visit and what to bring.
+  </p>
+
+  <p class="govuk-!-margin-bottom-2">
+    What you tell us might include:
+  </p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      there is no, or limited mobile reception
+    </li>
+    <li>
+      access is blocked
+    </li>
+    <li>
+      ladders or other equipment is needed
+    </li>
+    <li>
+      site health and safety rules need to be followed (for instance, a hard hat, boots and hi visibility clothing)
+    </li>
+    <li>
+      there is livestock or other animals
+    </li>
+    <li>
+      there is dangerous debris or overgrown vegetation
+    </li>
+    <li>
+      there is potentially hazardous material, such as asbestos
+    </li>
+  </ul> -->
+
+  {% set missingEvidenceHTML %}
+    {{ govukTextarea({
+      name: 'missing-evidence__detail',
+      id: 'missing-evidence__detail',
+      value: data['missing-evidence__detail'],
+      rows: '',
+      label: {
+        html: 'What evidence is missing?'
+      }
+    }) }}
+  {% endset -%}
+
+  {% set otherReasonHTML %}
+    {{ govukTextarea({
+      name: 'other__detail',
+      id: 'other__detail',
+      value: data['other__detail'],
+      rows: '',
+      label: {
+        html: 'Detail why the appeal is invalid'
+      }
+    }) }}
+  {% endset -%}
+
+  {{ govukRadios({
+    idPrefix: 'missing-evidence__reasons',
+    name: 'missing-evidence__reasons',
+    fieldset: {
+      legend: {
+        html: 'State why the appeal is invalid',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    items: [
+      {
+        html: 'Missing evidence',
+        value: 'Missing evidence',
+        checked: checked('missing-evidence__reasons','Missing evidence'),
+        conditional: {
+          html: missingEvidenceHTML
+        }
+      },
+      {
+        html: 'Another reason',
+        value: 'Another reason',
+        checked: checked('missing-evidence__reasons','Another reason'),
+        conditional: {
+          html: otherReasonHTML
+        }
+      }
+    ]
+  }) }}
+
+{% endblock %}
+
+{% block pageScripts %}{% endblock %}


### PR DESCRIPTION
Adding routing for decision types and ‘invalid’ cases, added a simple radio option for missing evidence and other reasons why an appeal would be made invalid.