### PR TITLE
Issuing decisions v2, personal list v1

### DIFF
--- a/app/views/projects/issue-decision/index.html
+++ b/app/views/projects/issue-decision/index.html
@@ -18,10 +18,10 @@
     <h2 class="govuk-heading-m">
       Version 2
 
-		{{govukTag({
-      text: "In progress",
-      classes: "govuk-!-margin-left-2 govuk-tag--yellow"
-    })}}
+  		{{govukTag({
+        text: "Ready for research",
+        classes: "govuk-!-margin-left-2 govuk-tag--green"
+      })}}
 
     </h2>
 
@@ -29,21 +29,22 @@
       As an Inspector I want to be able to issue appeal decisions.
     </p>
 
+    <p class="govuk-body">
+      Changes:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>content updates</li>
+    </ul>
+
+
   	{{ govukButton({
   	  text: "View prototype",
-  	  href: "v2/case?status=determination",
+  	  href: "/projects/personal-list/v1/?decision=ready",
   	  isStartButton: true
   	}) }}
 
     {% set v1HTML %}
-
-  	  <h2 class="govuk-heading-m">
-        Version 1
-
-  		{{govukTag({
-        text: "In progress",
-        classes: "govuk-!-margin-left-2 govuk-tag--yellow"
-      })}}
 
   		<!-- Status tag options
 
@@ -73,8 +74,6 @@
       })}}
 
       -->
-
-      </h2>
 
       <p class="govuk-body">
         As an Inspector I want to be able to issue appeal decisions.

--- a/app/views/projects/issue-decision/v2/_routes.js
+++ b/app/views/projects/issue-decision/v2/_routes.js
@@ -9,7 +9,7 @@ router.get('*', function(req, res, next){
 })
 
 router.post('/invalid', function (req, res) {
-  res.redirect('case?status=incomplete')
+  res.redirect('case?status=incomplete&decision=incomplete-appeal')
 })
 
 router.post('/upload-decision', function (req, res) {

--- a/app/views/projects/issue-decision/v2/appellant-case.html
+++ b/app/views/projects/issue-decision/v2/appellant-case.html
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
-  	<span class="govuk-caption-l">Appeal 2110166</span>
+  	<span class="govuk-caption-l">Appeal 1234562</span>
   	<h1 class="govuk-heading-l">Appellant case</h1>
 
     {% include "../v2/includes/case-meta-data.html" %}

--- a/app/views/projects/issue-decision/v2/case.html
+++ b/app/views/projects/issue-decision/v2/case.html
@@ -3,10 +3,17 @@
 {% set pageName="Case details" %}
 
 {% block backLink %}
-  {{ govukBackLink({
-    text: "Back to national list",
-    href: 'javascript:history.back()'
-  }) }}
+  {% if data['decision'] == 'incomplete-appeal' %}
+    {{ govukBackLink({
+      text: "Back to personal list",
+      href: '/projects/personal-list/v1/?decision=incomplete-appeal'
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      text: "Back to personal list",
+      href: '/projects/personal-list/v1/'
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -18,11 +25,11 @@
 
     {% if data['status'] == 'determination' %}
   	  <p class="govuk-notification-banner__heading">
-  	    The appeal is ready for determination
+  	    The appeal is ready for a decision
   	  </p>
   	  <p>
         <a class="govuk-notification-banner__link" href="decision.html">
-          Issue a determination
+          Issue a decision
         </a>
       </p>
     {% elif data['status'] == 'incomplete' %}
@@ -40,6 +47,10 @@
         </p>
       {% endif %}
 
+    {% elif data['status'] == 'done' %}
+      <p class="govuk-notification-banner__heading">
+        The appeal decision has been issued
+      </p>
     {% endif %}
 
 	{% endset %}
@@ -48,7 +59,7 @@
 	  html: html
 	}) }}
 
-	<span class="govuk-caption-l">Appeal 2110166</span>
+	<span class="govuk-caption-l">Appeal 1234562</span>
 	<h1 class="govuk-heading-l">Case details</h1>
 
   {% if data['status'] == 'ready-to-start' %}
@@ -89,7 +100,7 @@
   {% elif data['status'] == 'determination' %}
 
     {{ govukTag({
-      text: "Issue determination",
+      text: "Ready for final review",
       classes: "govuk-tag--pink"
     })}}
 
@@ -122,7 +133,11 @@
 	      </h2>
 	    </div>
 	    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
-			{% include "projects/appellant-case/includes/case-overview-table.html" %}
+      {% if data['status'] != 'done' %}
+        {% include "../v2/includes/case-overview-table" %}
+      {% else %}
+        {% include "../v2/includes/case-overview-table-done" %}
+      {% endif %}
 	    </div>
 	  </div>
 	  <div class="govuk-accordion__section">

--- a/app/views/projects/issue-decision/v2/check-your-answers.html
+++ b/app/views/projects/issue-decision/v2/check-your-answers.html
@@ -13,22 +13,22 @@
     {{ title }}
   </h1>
 
-  {{ govukTag({
+  <!-- {{ govukTag({
     text: "Issue determination",
     classes: "govuk-tag--pink"
-  })}}
+  })}} -->
 
-</div>
+<!-- </div>
 <div class="govuk-grid-column-full">
 
   {% include "../v2/includes/case-meta-data.html" %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 </div>
-<div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-column-two-thirds"> -->
 
   {{ govukSummaryList({
-    classes: 'govuk-!-margin-bottom-9',
+    classes: 'govuk-!-margin-bottom-6',
     rows: [
       {
         key: {

--- a/app/views/projects/issue-decision/v2/confirmation.html
+++ b/app/views/projects/issue-decision/v2/confirmation.html
@@ -26,7 +26,7 @@
     </p>
 
     <p class="govuk-body">
-      <a href='#' class='govuk-link'>
+      <a href='/projects/personal-list/v1/?decision=done' class='govuk-link'>
         Back to your list
       </a>
     </p>

--- a/app/views/projects/issue-decision/v2/decision-date.html
+++ b/app/views/projects/issue-decision/v2/decision-date.html
@@ -9,32 +9,32 @@
   <span class="govuk-caption-l">
     Appeal 2110166
   </span>
-  <h1 class="govuk-heading-l">
+  <!-- <h1 class="govuk-heading-l">
     {{ title }}
-  </h1>
+  </h1> -->
 
-  {{ govukTag({
+  <!-- {{ govukTag({
     text: "Issue determination",
     classes: "govuk-tag--pink"
-  })}}
+  })}} -->
 
-</div>
+<!-- </div>
 <div class="govuk-grid-column-full">
 
   {% include "../v2/includes/case-meta-data.html" %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 </div>
-<div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-column-two-thirds"> -->
 
   {{ govukDateInput({
     id: "decision-date",
     namePrefix: "decision-date",
     fieldset: {
       legend: {
-        text: "Decision date on the letter",
-        isPageHeading: false,
-        classes: "govuk-fieldset__legend--m"
+        text: title,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
       }
     },
     hint: {

--- a/app/views/projects/issue-decision/v2/decision.html
+++ b/app/views/projects/issue-decision/v2/decision.html
@@ -13,19 +13,19 @@
     {{ title }}
   </h1>
 
-  {{ govukTag({
+  <!-- {{ govukTag({
     text: "Issue determination",
-    classes: "govuk-tag--pink"
-  })}}
+    classes: "govuk-tag--pink govuk-!-margin-bottom-6"
+  })}} -->
 
-</div>
+<!-- </div>
 <div class="govuk-grid-column-full">
 
   {% include "../v2/includes/case-meta-data.html" %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 </div>
-<div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-column-two-thirds"> -->
 
   {{ govukRadios({
     name: "issued-decision",

--- a/app/views/projects/issue-decision/v2/has-lpaq.html
+++ b/app/views/projects/issue-decision/v2/has-lpaq.html
@@ -6,7 +6,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-3">
 
-      <span class="govuk-caption-l">Appeal 0123456</span>
+      <span class="govuk-caption-l">Appeal 1234562</span>
       <h1 class="govuk-heading-l">
         {{ title }}
       </h1>

--- a/app/views/projects/issue-decision/v2/includes/case-overview-table-done.html
+++ b/app/views/projects/issue-decision/v2/includes/case-overview-table-done.html
@@ -1,0 +1,99 @@
+{{ govukTable({
+	  captionClasses: "govuk-table__caption--m",
+	  firstCellIsHeader: true,
+	  rows: [
+	    [
+	      {
+	        text: "Appeal type"
+	      },
+	      {
+	        text: "Householder appeal (HAS)"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],
+	    [
+	      {
+	        text: "Case procedure"
+	      },
+	      {
+	        text: "Written"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],
+	    [
+	      {
+	        text: "Appellant name"
+	      },
+	      {
+	        text: "Fiona Shell"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Agent name"
+	      },
+	      {
+	        text: "Naomi Jonhson"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Linked appeal"
+	      },
+	      {
+	        html: "<a href='.'>21/725284</a>"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Other appeals"
+	      },
+	      {
+	        html: "<a href='.'>21/725234</a>"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Allocation details"
+	      },
+	      {
+	        text: "F / General Allocation"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "LPA reference"
+	      },
+	      {
+	        text: "22/00118/FULL"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Decision"
+	      },
+	      {
+	        html: "<a href='#'>decision-letter.pdf</a>"
+	      },
+	      {
+	        html: ""
+	      }
+	    ]
+	  ]
+	}) }}

--- a/app/views/projects/issue-decision/v2/includes/case-overview-table.html
+++ b/app/views/projects/issue-decision/v2/includes/case-overview-table.html
@@ -1,0 +1,99 @@
+{{ govukTable({
+	  captionClasses: "govuk-table__caption--m",
+	  firstCellIsHeader: true,
+	  rows: [
+	    [
+	      {
+	        text: "Appeal type"
+	      },
+	      {
+	        text: "Householder appeal (HAS)"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],
+	    [
+	      {
+	        text: "Case procedure"
+	      },
+	      {
+	        text: "Written"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],
+	    [
+	      {
+	        text: "Appellant name"
+	      },
+	      {
+	        text: "Fiona Shell"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Agent name"
+	      },
+	      {
+	        text: "Naomi Jonhson"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Linked appeal"
+	      },
+	      {
+	        html: "<a href='.'>21/725284</a>"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Other appeals"
+	      },
+	      {
+	        html: "<a href='.'>21/725234</a>"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Allocation details"
+	      },
+	      {
+	        text: "F / General Allocation"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "LPA reference"
+	      },
+	      {
+	        text: "22/00118/FULL"
+	      },
+	      {
+	        html: "<a href='#'>Change</a>"
+	      }
+	    ],[
+	      {
+	        text: "Decision"
+	      },
+	      {
+	        text: "Not issued yet"
+	      },
+	      {
+	        html: ""
+	      }
+	    ]
+	  ]
+	}) }}

--- a/app/views/projects/issue-decision/v2/upload-decision.html
+++ b/app/views/projects/issue-decision/v2/upload-decision.html
@@ -13,21 +13,21 @@
     {{ title }}
   </h1>
 
-  {{ govukTag({
+  <!-- {{ govukTag({
     text: "Issue determination",
     classes: "govuk-tag--pink"
-  })}}
+  })}} -->
 
-</div>
+<!-- </div>
 <div class="govuk-grid-column-full">
 
   {% include "../v2/includes/case-meta-data.html" %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 </div>
-<div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-column-two-thirds"> -->
 
-  <section class="govuk-!-margin-bottom-6">
+  <section class="govuk-!-margin-top-6 govuk-!-margin-bottom-6">
 
     {{ govukWarningText({
       text: "Before uploading the decision letter check the following things:",

--- a/app/views/projects/personal-list/index.html
+++ b/app/views/projects/personal-list/index.html
@@ -14,42 +14,15 @@
       Personal list
     </h1>
 
-	  <h2 class="govuk-heading-m">
-      Version 1
+    {% set version = "2" %}
 
-		{{govukTag({
-      text: "Ready for research",
-      classes: "govuk-!-margin-left-2 govuk-tag--green"
-    })}}
-
-		<!-- Status tag options
-
-		{{govukTag({
-      text: "New",
-      classes: "govuk-!-margin-left-2 govuk-tag--green"
-    })}}
-
-    {{govukTag({
-      text: "In progress",
-      classes: "govuk-!-margin-left-2 govuk-tag--yellow"
-    })}}
-
-    {{govukTag({
-      text: "Ready for review",
-      classes: "govuk-!-margin-left-2 govuk-tag--blue"
-    })}}
+    <h2 class="govuk-heading-m">
+      Version {{version}}
 
     {{govukTag({
       text: "Ready for research",
       classes: "govuk-!-margin-left-2 govuk-tag--green"
     })}}
-
-    {{govukTag({
-      text: "Researched",
-      classes: " govuk-!-margin-left-2 govuk-tag--green"
-    })}}
-
-    -->
 
     </h2>
 
@@ -57,11 +30,47 @@
       I want to view my personal list so that I can see all the cases that are assigned to me
     </p>
 
-  	{{ govukButton({
-  	  text: "View prototype",
-  	  href: "v1/",
-  	  isStartButton: true
-  	}) }}
+    {{ govukButton({
+      text: "View prototype",
+      href: "v2/",
+      isStartButton: true
+    }) }}
+
+    {% set v1HTML %}
+
+      {% set version = "1" %}
+
+      <p class="govuk-body">
+        I want to view my personal list so that I can see all the cases that are assigned to me.
+      </p>
+
+      <p class="govuk-body">
+        For August user research with Inspectors.
+      </p>
+
+    	{{ govukButton({
+    	  text: "View prototype",
+    	  href: "v1/?decision=ready",
+    	  isStartButton: true
+    	}) }}
+
+    {% endset -%}
+
+    {{ govukAccordion({
+      id: 'previous',
+      classes: 'govuk-!-margin-top-5',
+      items: [
+
+        {
+          heading: {
+            html: 'Version 1 <strong class="govuk-tag govuk-tag--green govuk-!-margin-left-2">Ready for research</strong>'
+          },
+          content: {
+            html: v1HTML
+          }
+        }
+      ]
+    }) }}
 
 
   	<details class="govuk-details" data-module="govuk-details">

--- a/app/views/projects/personal-list/v2/_archive/perosnal-list.html
+++ b/app/views/projects/personal-list/v2/_archive/perosnal-list.html
@@ -1,0 +1,25 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Personal list" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">Cases assigned to you</h1>
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+	  {% include "projects/personal-list/v1/includes/personal-list-table.html" %}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/_archive/personal-list-table.html
+++ b/app/views/projects/personal-list/v2/_archive/personal-list-table.html
@@ -1,0 +1,56 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Appeal ID</th>
+      <th scope="col" class="govuk-table__header">Status</th>
+      <th scope="col" class="govuk-table__header">Action required</th>
+      <th scope="col" class="govuk-table__header">Due by</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=ready-to-start">2110166</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+      <td class="govuk-table__cell">Appellant case <br>valid<br><a href="#">View</a></td>
+      <td class="govuk-table__cell">10 July 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=lpa-questionnaire">2110167</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">LPA questionnaire</strong></td>
+      <td class="govuk-table__cell">LPA Questionnaire <br>received<br><a href="#">Review</a></td>
+      <td class="govuk-table__cell">11 July 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=statement-review">2110168</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange">Statement review</strong></td>
+      <td class="govuk-table__cell">Not received</td>
+      <td class="govuk-table__cell">12 July 2023</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="#">1234560</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
+      <td class="govuk-table__cell">IP comments/final comments<br>received<br><a href="#">Review</a></td>
+      <td class="govuk-table__cell">13 July 2023</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=determination">1234562</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=site-visit">1234561</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Arrange site visit</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=complete">1234563</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/projects/personal-list/v2/case.html
+++ b/app/views/projects/personal-list/v2/case.html
@@ -1,0 +1,175 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Case details" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+    	{% set html %}
+    	  <p class="govuk-notification-banner__heading">
+    	    The appeal is ready for review
+    	  </p>
+    	  <p>
+          <a class="govuk-notification-banner__link" href="appellant-case.html">
+            Start the review
+          </a>
+        </p>
+    	{% endset %}
+
+    	<span class="govuk-caption-l">Appeal 2110166</span>
+    	<h1 class="govuk-heading-l">Case details</h1>
+
+      {% if data['status'] == 'determination' %}
+
+        {{ govukTag({
+          text: "Issue determination",
+          classes: "govuk-tag--pink"
+        })}}
+
+      {% else %}
+
+        {{ govukTag({
+          text: "Ready to start",
+          classes: "govuk-tag--green"
+        })}}
+
+      {% endif %}
+
+
+      {% include "/includes/appeal-content/lpa-has-appeal-meta.html" %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    	<!-- {{ govukSummaryList({
+    	  classes: 'govuk-summary-list--no-border govuk-!-margin-top-6',
+    	  rows: [
+    	    {
+    	      key: {
+    	        text: "Site address"
+    	      },
+    	      value: {
+    	        text: "Address line 1, Address line 2, Town or city, Postcode"
+    	      }
+    	    },
+    	    {
+    	      key: {
+    	        text: "Local planning authority"
+    	      },
+    	      value: {
+    	        text: "Council name"
+    	      }
+    	    }
+    	  ]
+    	}) }} -->
+
+      <div class="govuk-accordion govuk-!-margin-top-9" data-module="govuk-accordion" id="accordion-default">
+        <div class="govuk-accordion__section">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+                Case overview
+              </span>
+            </h2>
+          </div>
+          <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+      		    {% include "/includes/audit/case-overview-table.html" %}
+          </div>
+        </div>
+        <div class="govuk-accordion__section">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+                Case timetable
+              </span>
+            </h2>
+          </div>
+
+          <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+          	{{ govukInsetText({
+          	  html: "<p class='govuk-body'>Case not started</p><p><a href='appellant-case.html'>Start the review</a></p>"
+          	}) }}
+          </div>
+        </div>
+
+        <div class="govuk-accordion__section">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+                Case documentation
+              </span>
+            </h2>
+          </div>
+          <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+            {% include "/includes/audit/case-documentation-table.html" %}
+          </div>
+        </div>
+        <div class="govuk-accordion__section">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+                Case team
+              </span>
+            </h2>
+          </div>
+          <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+            {% include "/includes/audit/case-team-table.html" %}
+          </div>
+        </div>
+      </div>
+
+    	<h3 class="govuk-heading-m govuk-!-margin-top-9">
+        Audit history
+      </h3>
+    	<p class="govuk-body">
+        <a href="history">View changes</a> that have been made to this account
+      </p>
+
+    </div>
+  </div>
+
+  {% if data['status'] == 'determination' %}
+
+    <form action="" method="post" class="govuk-!-margin-top-6" novalidate>
+
+      <!-- this form is branching using https://github.com/abbott567/radio-button-redirect for simpler routing-->
+
+        {{ govukRadios({
+          name: "issue-decision",
+          fieldset: {
+            legend: {
+              text: "Issue your decision",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "allowed~../../issue-decision/v1/decision-date",
+              text: "Allowed"
+            },
+            {
+              value: "dismissed~../../issue-decision/v1/decision-date",
+              text: "Dismissed"
+            },
+            {
+              value: "split~../../issue-decision/v1/decision-date",
+              text: "Split-decision"
+            },
+            {
+              value: "invalid~../../issue-decision/v1/decision-date",
+              text: "Invalid"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+    </form>
+
+  {% endif %}
+
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/cases-search-asis-assigned.html
+++ b/app/views/projects/personal-list/v2/cases-search-asis-assigned.html
@@ -1,0 +1,80 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Case officer home" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">National list</h1>
+
+
+	{{ govukInput({
+	  label: {
+	    text: "Search cases",
+	    classes: "govuk-label--m",
+	    isPageHeading: false
+	  },
+	  classes: "",
+	  hint: {
+	    text: "Enter appeal ID or postcode"
+	  },
+	  id: "account-number",
+	  name: "account-number",
+	  inputmode: "numeric",
+	  spellcheck: false
+	}) }}
+
+	<div class="govuk-button-group">
+	  <button class="govuk-button" data-module="govuk-button">
+	    Search
+	  </button>
+	</div>
+		
+	<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">	
+
+
+  </div>
+</div>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+	  
+	  <p class="govuk-!-margin-bottom-8"><a href="cases-search-asis">Show all cases</a></p>
+	  
+	  <h2 class="govuk-heading-m">Cases assigned to me</h2>
+
+	  {% include "projects/personal-list/v1/includes/personal-list-table.html" %}
+
+	{{ govukPagination({
+	  previous: {
+	    href: "#"
+	  },
+	  next: {
+	    href: "#"
+	  },
+	  items: [
+	    {
+	      number: 1,
+	      current: true,
+	      href: "#"
+	    },
+	    {
+	      number: 2,
+	      href: "#"
+	    },
+	    {
+	      number: 3,
+	      href: "#"
+	    }
+	  ]
+	}) }}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/cases-search-asis.html
+++ b/app/views/projects/personal-list/v2/cases-search-asis.html
@@ -1,0 +1,81 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Case officer home" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">National list</h1>
+
+
+	{{ govukInput({
+	  label: {
+	    text: "Search cases",
+	    classes: "govuk-label--m",
+	    isPageHeading: false
+	  },
+	  classes: "",
+	  hint: {
+	    text: "Enter appeal ID or postcode"
+	  },
+	  id: "account-number",
+	  name: "account-number",
+	  inputmode: "numeric",
+	  spellcheck: false
+	}) }}
+
+	<div class="govuk-button-group">
+	  <button class="govuk-button" data-module="govuk-button">
+	    Search
+	  </button>
+	</div>
+		
+	<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">	
+
+
+  </div>
+</div>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+	  
+	  <p class="govuk-!-margin-bottom-8"><a href="cases-search-asis-assigned">Show cases assigned to me</a></p>
+	  
+	  
+	  <h2 class="govuk-heading-m">All cases</h2>
+
+	  {% include "projects/personal-list/v1/includes/national-list-table.html" %}
+
+	{{ govukPagination({
+	  previous: {
+	    href: "#"
+	  },
+	  next: {
+	    href: "#"
+	  },
+	  items: [
+	    {
+	      number: 1,
+	      current: true,
+	      href: "#"
+	    },
+	    {
+	      number: 2,
+	      href: "#"
+	    },
+	    {
+	      number: 3,
+	      href: "#"
+	    }
+	  ]
+	}) }}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/includes/national-list-table.html
+++ b/app/views/projects/personal-list/v2/includes/national-list-table.html
@@ -1,0 +1,63 @@
+<table class="govuk-table">
+<!-- <caption class="govuk-table__caption govuk-table__caption--s">All cases:</caption> -->
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+  <th scope="col" class="govuk-table__header">Appeal ID</th>
+  <th scope="col" class="govuk-table__header">Site address</th>
+  <th scope="col" class="govuk-table__header">Local planning authority</th>
+  <th scope="col" class="govuk-table__header">Appeal type</th>
+  <th scope="col" class="govuk-table__header">Status</th>
+</tr>
+</thead>
+<tbody class="govuk-table__body">
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">2110166</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">2110167</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">LPA questionnaire</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">2110168</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange">Statement review</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="#">1234560</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">1234561</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Arrange site visit</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">1234562</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
+</tr>
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header"><a href="case.html">1234563</a></th>
+  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+  <td class="govuk-table__cell">Council name</td>
+  <td class="govuk-table__cell">Appeal type</td>
+  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
+</tr>
+</tbody>
+</table>

--- a/app/views/projects/personal-list/v2/includes/personal-list-table-status-action.html
+++ b/app/views/projects/personal-list/v2/includes/personal-list-table-status-action.html
@@ -1,0 +1,64 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Appeal ID</th>
+      <th scope="col" class="govuk-table__header">Case status</th>
+      <th scope="col" class="govuk-table__header">Document status</th>
+      <th scope="col" class="govuk-table__header">Due by</th>
+      <th scope="col" class="govuk-table__header">Action</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=ready-to-start">2110166</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+      <td class="govuk-table__cell">Appellant case<br>Valid</td>
+      <td class="govuk-table__cell">10 July 2023</td>
+      <td class="govuk-table__cell"><a href="#">View</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=lpa-questionnaire">2110167</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">LPA questionnaire</strong></td>
+      <td class="govuk-table__cell">LPA questionnaire<br>Recieved</td>
+      <td class="govuk-table__cell">11 July 2023</td>
+      <td class="govuk-table__cell"><a href="#">Review</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=statement-review">2110168</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange">Statement review</strong></td>
+      <td class="govuk-table__cell">Statements<br>Not received</td>
+      <td class="govuk-table__cell">12 July 2023</td>
+      <td class="govuk-table__cell"><a href="#"></a></td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="#">1234560</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
+      <td class="govuk-table__cell">IP comments/final comments<br>Recieved</td>
+      <td class="govuk-table__cell">13 July 2023</td>
+      <td class="govuk-table__cell"><a href="#">View</a></td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=determination">1234562</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=site-visit">1234561</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Arrange site visit</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html?status=complete">1234563</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/projects/personal-list/v2/includes/personal-list-table-status.html
+++ b/app/views/projects/personal-list/v2/includes/personal-list-table-status.html
@@ -1,0 +1,57 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Appeal ID</th>
+      <th scope="col" class="govuk-table__header"></th>
+      <th scope="col" class="govuk-table__header">Document status</th>
+      <th scope="col" class="govuk-table__header">Due by</th>
+      <th scope="col" class="govuk-table__header">Case status</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110166</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+      <td class="govuk-table__cell">Appellant case<br>Valid</td>
+      <td class="govuk-table__cell">10 July 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110167</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">LPA questionnaire</strong></td>
+      <td class="govuk-table__cell">LPA questionnaire<br>Incomplete</td>
+      <td class="govuk-table__cell">11 July 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">2110168</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange">Statement review</strong></td>
+      <td class="govuk-table__cell">Statements<br>Not received</td>
+      <td class="govuk-table__cell">12 July 2023</td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="#">1234560</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
+      <td class="govuk-table__cell">IP comments/final comments<br>Incomplete</td>
+      <td class="govuk-table__cell">13 July 2023</td>
+    </tr>
+    
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234562</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234561</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Arrange site visit</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"><a href="case.html">1234563</a></th>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/projects/personal-list/v2/includes/personal-list-table-v2.html
+++ b/app/views/projects/personal-list/v2/includes/personal-list-table-v2.html
@@ -1,0 +1,62 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Action required</th>
+      <th scope="col" class="govuk-table__header">Due by</th>
+      <th scope="col" class="govuk-table__header">Case status</th>
+      <th scope="col" class="govuk-table__header">Appeal ID</th>
+      <th scope="col" class="govuk-table__header"></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="#">View appellant case</a></td>
+      <td class="govuk-table__cell">10 July 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+      <td class="govuk-table__cell"><a href="case.html?status=ready-to-start">2110166</a></td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey">Lead</strong></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="#">Review LPA Questionnaire</a></td>
+      <td class="govuk-table__cell">11 July 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">LPA questionnaire</strong></td>
+      <td class="govuk-table__cell"><a href="case.html?status=lpa-questionnaire">2110167</a></td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey">Child</strong></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Not received</td>
+      <td class="govuk-table__cell">12 July 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange">Statement review</strong></td>
+      <td class="govuk-table__cell"><a href="case.html?status=statement-review">2110168</a></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="#">Review IP comments/final comments</a></td>
+      <td class="govuk-table__cell">13 July 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
+      <td class="govuk-table__cell"><a href="case.html?status=statement-review">1234560</a></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
+      <td class="govuk-table__cell"><a href="case.html">1234562</a></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Arrange site visit</strong></td>
+      <td class="govuk-table__cell"><a href="case.html?status=site-visit">1234561</a></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
+      <td class="govuk-table__cell"><a href="case.html?status=complete">1234563</a></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/projects/personal-list/v2/includes/personal-list-table.html
+++ b/app/views/projects/personal-list/v2/includes/personal-list-table.html
@@ -38,32 +38,11 @@
       <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Final comment review</strong></td>
     </tr>
     <tr class="govuk-table__row">
-
-      {% if data['decision'] == 'ready' %}
-        <td class="govuk-table__cell"><a href="/projects/issue-decision/v2/case?status=determination">1234562</a></td>
-      {% elif data['decision'] == 'incomplete-appeal' %}
-        <td class="govuk-table__cell"><a href="/projects/issue-decision/v2/case?status=incomplete">1234562</a></td>
-      {% elif data['decision'] == 'done' %}
-        <td class="govuk-table__cell"><a href="/projects/issue-decision/v2/case?status=done">1234562</a></td>
-      {% endif %}
-
+      <td class="govuk-table__cell"><a href="case.html">1234562</a></td>
       <td class="govuk-table__cell"></td>
-      {% if data['decision'] == 'ready' %}
-        <td class="govuk-table__cell"><a href="/projects/issue-decision/v2/decision" class="govuk-link govuk-link--no-visited-state">Issue a decision</a></td>
-      {% elif data['decision'] == 'incomplete-appeal' %}
-        <td class="govuk-table__cell"><a href="#" class="govuk-link govuk-link--no-visited-state">Review case</a></td>
-      {% else %}
-        <td class="govuk-table__cell"></td>
-      {% endif %}
       <td class="govuk-table__cell"></td>
-      {% if data['decision'] == 'ready' %}
-        <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Ready for final review</strong></td>
-      {% elif data['decision'] == 'incomplete-appeal' %}
-        <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red">Incomplete</strong></td>
-      {% else %}
-        <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Completed</strong></td>
-      {% endif %}
-
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--pink">Issue determination</strong></td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><a href="case.html?status=site-visit">1234561</a></td>
@@ -76,7 +55,7 @@
       <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey">Child</strong></td>
       <td class="govuk-table__cell"></td>
       <td class="govuk-table__cell"></td>
-      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Completed</strong></td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Complete</strong></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/projects/personal-list/v2/index-status-action.html
+++ b/app/views/projects/personal-list/v2/index-status-action.html
@@ -1,0 +1,25 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Personal list" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+	  
+  <h1 class="govuk-heading-l">Cases assigned to you</h1>
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+	  {% include "projects/personal-list/v1/includes/personal-list-table-status-action.html" %}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/index-status.html
+++ b/app/views/projects/personal-list/v2/index-status.html
@@ -1,0 +1,25 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Personal list" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+	  
+  <h1 class="govuk-heading-l">Cases assigned to you</h1>
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+	  {% include "projects/personal-list/v1/includes/personal-list-table-status.html" %}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/index.html
+++ b/app/views/projects/personal-list/v2/index.html
@@ -1,0 +1,25 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Personal list" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">Cases assigned to you</h1>
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+	  {% include "projects/personal-list/v1/includes/personal-list-table.html" %}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/national-list.html
+++ b/app/views/projects/personal-list/v2/national-list.html
@@ -1,0 +1,81 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Case officer home" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">National list</h1>
+
+
+	{{ govukInput({
+	  label: {
+	    text: "Search cases",
+	    classes: "govuk-label--m",
+	    isPageHeading: false
+	  },
+	  classes: "",
+	  hint: {
+	    text: "Enter appeal ID or postcode"
+	  },
+	  id: "account-number",
+	  name: "account-number",
+	  inputmode: "numeric",
+	  spellcheck: false
+	}) }}
+
+	<div class="govuk-button-group">
+	  <button class="govuk-button" data-module="govuk-button">
+	    Search
+	  </button>
+	</div>
+		
+	<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">	
+
+
+  </div>
+</div>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+	  
+	  <p class="govuk-!-margin-bottom-8"><a href="cases-search-asis-assigned">Show cases assigned to me</a></p>
+	  
+	  
+	  <h2 class="govuk-heading-m">All cases</h2>
+
+	  {% include "projects/personal-list/v1/includes/national-list-table.html" %}
+
+	{{ govukPagination({
+	  previous: {
+	    href: "#"
+	  },
+	  next: {
+	    href: "#"
+	  },
+	  items: [
+	    {
+	      number: 1,
+	      current: true,
+	      href: "#"
+	    },
+	    {
+	      number: 2,
+	      href: "#"
+	    },
+	    {
+	      number: 3,
+	      href: "#"
+	    }
+	  ]
+	}) }}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/personal-list-mix-allCases.html
+++ b/app/views/projects/personal-list/v2/personal-list-mix-allCases.html
@@ -1,0 +1,112 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Personal list" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">National list</h1>
+
+
+	{{ govukInput({
+	  label: {
+	    text: "Search cases",
+	    classes: "govuk-label--m",
+	    isPageHeading: false
+	  },
+	  classes: "",
+	  hint: {
+	    text: "Enter appeal ID or postcode"
+	  },
+	  id: "account-number",
+	  name: "account-number",
+	  inputmode: "numeric",
+	  spellcheck: false
+	}) }}
+
+	<div class="govuk-button-group">
+	  <button class="govuk-button" data-module="govuk-button">
+	    Search
+	  </button>
+	</div>
+	
+	<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+	
+
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+	  
+	  	
+	  	<form action="personal-list-mix" method="post" class="" novalidate>
+
+		{{ govukRadios({
+		  classes: "govuk-radios--inline",
+		  name: "whoAssigned",
+		  value: "all cases",
+		  fieldset: {
+		    legend: {
+		      text: "Filter cases",
+		      isPageHeading: false,
+		      classes: "govuk-fieldset__legend--m"
+		    }
+		  },
+		  items: [
+		    {
+		      value: "assigned to me",
+		      text: "Assigned to me"
+		    },
+		    {
+		      value: "all cases",
+		      text: "All cases"
+		    }
+		  ]
+		}) }}
+		
+		{{ govukButton({
+          text: "Apply",
+          classes: "govuk-button--secondary"
+        }) }}
+		
+	  	</form>
+			  
+	  
+  	  {% include "projects/personal-list/v1/includes/national-list-table.html" %}
+
+
+	{{ govukPagination({
+	  previous: {
+	    href: "#"
+	  },
+	  next: {
+	    href: "#"
+	  },
+	  items: [
+	    {
+	      number: 1,
+	      current: true,
+	      href: "#"
+	    },
+	    {
+	      number: 2,
+	      href: "#"
+	    },
+	    {
+	      number: 3,
+	      href: "#"
+	    }
+	  ]
+	}) }}
+	
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/personal-list-mix-tab-search-res.html
+++ b/app/views/projects/personal-list/v2/personal-list-mix-tab-search-res.html
@@ -1,0 +1,106 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Personal list" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">National list</h1>
+
+
+	{{ govukInput({
+	  label: {
+	    text: "Search cases",
+	    classes: "govuk-label--m",
+	    isPageHeading: false
+	  },
+	  classes: "",
+	  hint: {
+	    text: "Enter appeal ID or postcode"
+	  },
+	  id: "account-number",
+	  name: "account-number",
+	  inputmode: "numeric",
+	  spellcheck: false
+	}) }}
+
+	{{ govukButton({
+	  text: "Search",
+	  href: "personal-list-mix-tab-search-res#all-cases"
+	}) }}
+	
+	<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+	
+	<p class="govuk-!-font-size-16">Search results for: <strong>2110166</strong></p>
+		
+	<p class="govuk-!-margin-bottom-8 govuk-!-font-size-16"><a href="personal-list-mix-tabs">Clear search results</a></p>
+	
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+	  
+	  
+	  <div class="govuk-tabs" data-module="govuk-tabs">
+	  <ul class="govuk-tabs__list">
+	    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+	      <a class="govuk-tabs__tab" href="#all-cases">
+	        All cases
+	      </a>
+	    </li>
+	    <li class="govuk-tabs__list-item">
+	      <a class="govuk-tabs__tab" href="#assigned-to-me">
+	        Assigned to me
+	      </a>
+	    </li>
+	  </ul>
+	  <div class="govuk-tabs__panel" id="all-cases">
+		  
+		 <table class="govuk-table">
+			<thead class="govuk-table__head">
+			<tr class="govuk-table__row">
+			  <th scope="col" class="govuk-table__header">Appeal ID</th>
+			  <th scope="col" class="govuk-table__header">Site address</th>
+			  <th scope="col" class="govuk-table__header">Local planning authority</th>
+			  <th scope="col" class="govuk-table__header">Appeal type</th>
+			  <th scope="col" class="govuk-table__header">Status</th>
+			</tr>
+			</thead>
+			<tbody class="govuk-table__body">
+			<tr class="govuk-table__row">
+			  <th scope="row" class="govuk-table__header"><a href="case.html">2110166</a></th>
+			  <td class="govuk-table__cell">Address line 1, Address line 2, Town or city, Postcode</td>
+			  <td class="govuk-table__cell">Council name</td>
+			  <td class="govuk-table__cell">Appeal type</td>
+			  <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>
+			</tr>
+			</tbody>
+		</table>
+		
+			
+	  </div>
+	  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="assigned-to-me">
+		  
+		<p>No results found </p>
+	    
+	  </div>
+	</div>
+
+	
+	
+
+	 
+
+
+
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/personal-list-mix-tabs.html
+++ b/app/views/projects/personal-list/v2/personal-list-mix-tabs.html
@@ -1,0 +1,119 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Personal list" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">National list</h1>
+
+
+	{{ govukInput({
+	  label: {
+	    text: "Search cases",
+	    classes: "govuk-label--m",
+	    isPageHeading: false
+	  },
+	  classes: "",
+	  hint: {
+	    text: "Enter appeal ID or postcode"
+	  },
+	  id: "account-number",
+	  name: "account-number",
+	  inputmode: "numeric",
+	  spellcheck: false
+	}) }}
+
+	{{ govukButton({
+	  text: "Search",
+	  href: "personal-list-mix-tab-search-res#all-cases"
+	}) }}
+	
+
+  </div>
+</div>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+	  
+	  
+	  <div class="govuk-tabs" data-module="govuk-tabs">
+	  <ul class="govuk-tabs__list">
+	    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+	      <a class="govuk-tabs__tab" href="#all-cases">
+	        All cases
+	      </a>
+	    </li>
+	    <li class="govuk-tabs__list-item">
+	      <a class="govuk-tabs__tab" href="#assigned-to-me">
+	        Assigned to me
+	      </a>
+	    </li>
+	  </ul>
+	  <div class="govuk-tabs__panel" id="all-cases">
+		  
+		 {% include "projects/personal-list/v1/includes/national-list-table.html" %}
+		
+		
+		{{ govukPagination({
+		  previous: {
+		    href: "#"
+		  },
+		  next: {
+		    href: "#"
+		  },
+		  items: [
+		    {
+		      number: 1,
+		      current: true,
+		      href: "#"
+		    },
+		    {
+		      number: 2,
+		      href: "#"
+		    },
+		    {
+		      number: 3,
+		      href: "#"
+		    }
+		  ]
+		}) }}
+	
+	  </div>
+	  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="assigned-to-me">
+		  
+		   {% include "projects/personal-list/v1/includes/personal-list-table.html" %}
+		
+		{{ govukPagination({
+		  previous: {
+		    href: "#"
+		  },
+		  next: {
+		    href: "#"
+		  },
+		  items: [
+		    {
+		      number: 1,
+		      current: true,
+		      href: "#"
+		    },
+		    {
+		      number: 2,
+		      href: "#"
+		    }
+		  ]
+		}) }}	  
+	    
+	  </div>
+	</div>
+
+	
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/projects/personal-list/v2/personal-list-mix.html
+++ b/app/views/projects/personal-list/v2/personal-list-mix.html
@@ -1,0 +1,108 @@
+{% extends "layouts/PINS.html" %}
+
+{% set pageName="Personal list" %}
+
+{% set back = false %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">National list</h1>
+
+
+	{{ govukInput({
+	  label: {
+	    text: "Search cases",
+	    classes: "govuk-label--m",
+	    isPageHeading: false
+	  },
+	  classes: "",
+	  hint: {
+	    text: "Enter appeal ID or postcode"
+	  },
+	  id: "account-number",
+	  name: "account-number",
+	  inputmode: "numeric",
+	  spellcheck: false
+	}) }}
+
+	<div class="govuk-button-group">
+	  <button class="govuk-button" data-module="govuk-button">
+	    Search
+	  </button>
+	</div>
+	
+	<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+	
+
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+	  
+	  	
+	  	<form action="personal-list-mix-allCases" method="post" class="" novalidate>
+
+		{{ govukRadios({
+		  classes: "govuk-radios--inline",
+		  name: "whoAssigned",
+		  value: "assigned to me",
+		  fieldset: {
+		    legend: {
+		      text: "Filter cases",
+		      isPageHeading: false,
+		      classes: "govuk-fieldset__legend--m"
+		    }
+		  },
+		  items: [
+		    {
+		      value: "assigned to me",
+		      text: "Assigned to me"
+		    },
+		    {
+		      value: "all cases",
+		      text: "All cases"
+		    }
+		  ]
+		}) }}
+		
+		{{ govukButton({
+          text: "Apply",
+          classes: "govuk-button--secondary"
+        }) }}
+		
+	  	</form>
+			  
+	  
+	   {% include "projects/personal-list/v1/includes/personal-list-table.html" %}
+	  
+	
+	{{ govukPagination({
+	  previous: {
+	    href: "#"
+	  },
+	  next: {
+	    href: "#"
+	  },
+	  items: [
+	    {
+	      number: 1,
+	      current: true,
+	      href: "#"
+	    },
+	    {
+	      number: 2,
+	      href: "#"
+	    }
+	  ]
+	}) }}
+
+
+  </div>
+</div>
+
+{% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "BO Appeals",
+  "name": "back-office-appeals-prototype",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,7 +8,7 @@
         "@govuk-prototype-kit/common-templates": "1.1.1",
         "@ministryofjustice/frontend": "^1.6.6",
         "govuk-frontend": "4.6.0",
-        "govuk-prototype-kit": "13.7.0",
+        "govuk-prototype-kit": "^13.12.2",
         "hmrc-frontend": "5.33.0",
         "jquery": "^3.7.0",
         "radio-button-redirect": "^1.2.0"
@@ -226,17 +226,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/async": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
@@ -266,10 +255,10 @@
         "follow-redirects": "^1.14.0"
       }
     },
-    "node_modules/bagpipe": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/bagpipe/-/bagpipe-0.3.5.tgz",
-      "integrity": "sha512-42sAlmPDKes1nLm/aly+0VdaopSU9br+jkRELedhQxI5uXHgtk47I83Mpmf4zoNTRMASdLFtUkimlu/Z9zQ8+g=="
+    "node_modules/b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -325,11 +314,6 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
-    },
-    "node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -1263,6 +1247,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -1519,9 +1508,9 @@
       }
     },
     "node_modules/govuk-prototype-kit": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-prototype-kit/-/govuk-prototype-kit-13.7.0.tgz",
-      "integrity": "sha512-54sXTo5acjGsDLhCFXneXtlq+Kl4kIOCxzZk2F5EsWP9orJIb3AjaOcDOtRYnmqGAnQQ0n95QOEm4x7AkrzdKQ==",
+      "version": "13.12.2",
+      "resolved": "https://registry.npmjs.org/govuk-prototype-kit/-/govuk-prototype-kit-13.12.2.tgz",
+      "integrity": "sha512-2QPCgoTXQSN0mfyQQwnRCAbzQl/X88iPLebcXLGa4UvQ6d8ADErGT6eRjPtWlg4l73mtM/Lwgd+WqsQ3Tksv4w==",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",
@@ -1539,15 +1528,16 @@
         "inquirer": "^8.2.0",
         "lodash": "^4.17.21",
         "marked": "^4.2.5",
-        "nodemon": "^2.0.20",
+        "nodemon": "^3.0.1",
         "nunjucks": "^3.2.3",
         "portscanner": "^2.2.0",
         "require-dir": "^1.2.0",
-        "sass": "^1.57.1",
-        "session-file-store": "^1.5.0",
+        "sass": "^1.66.1",
         "sync-request": "^6.1.0",
+        "tar-stream": "^3.1.2",
         "universal-analytics": "^0.5.3",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "zlib": "^1.0.5"
       },
       "bin": {
         "govuk-prototype-kit": "bin/cli"
@@ -1717,14 +1707,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -1858,11 +1840,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -1906,17 +1883,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/kruptein": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-2.2.3.tgz",
-      "integrity": "sha512-BTwprBPTzkFT9oTugxKd3WnWrX630MqUDsnmBuoa98eQs12oD4n4TeI0GbpdGcYn/73Xueg2rfnw+oK4dovnJg==",
-      "dependencies": {
-        "asn1.js": "^5.4.1"
-      },
-      "engines": {
-        "node": ">6"
       }
     },
     "node_modules/limiter": {
@@ -2022,6 +1988,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/marked": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -2109,11 +2086,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2157,17 +2129,17 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-      "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
+      "integrity": "sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==",
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^3.2.7",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.1.2",
         "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
         "undefsafe": "^2.0.5"
@@ -2176,7 +2148,7 @@
         "nodemon": "bin/nodemon.js"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=10"
       },
       "funding": {
         "type": "opencollective",
@@ -2513,6 +2485,11 @@
         }
       ]
     },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+    },
     "node_modules/radio-button-redirect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/radio-button-redirect/-/radio-button-redirect-1.2.0.tgz",
@@ -2617,14 +2594,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2716,9 +2685,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
-      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
+      "version": "1.66.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
+      "integrity": "sha512-50c+zTsZOJVgFfTgwwEzkjA3/QACgdNsKueWPyAR0mRINIvLAStVQBbPg14iuqEQ74NPDbXzJARJ/O4SI1zftA==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -2732,16 +2701,22 @@
       }
     },
     "node_modules/sass/node_modules/immutable": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -2899,51 +2874,6 @@
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ=="
     },
-    "node_modules/session-file-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/session-file-store/-/session-file-store-1.5.0.tgz",
-      "integrity": "sha512-60IZaJNzyu2tIeHutkYE8RiXVx3KRvacOxfLr2Mj92SIsRIroDsH0IlUUR6fJAjoTW4RQISbaOApa2IZpIwFdQ==",
-      "dependencies": {
-        "bagpipe": "^0.3.5",
-        "fs-extra": "^8.0.1",
-        "kruptein": "^2.0.4",
-        "object-assign": "^4.1.1",
-        "retry": "^0.12.0",
-        "write-file-atomic": "3.0.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/session-file-store/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/session-file-store/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/session-file-store/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -2987,22 +2917,14 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/simple-update-notifier": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
       "dependencies": {
-        "semver": "~7.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=10"
       }
     },
     "node_modules/slash": {
@@ -3162,6 +3084,15 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "node_modules/streamx": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
+      "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3224,6 +3155,16 @@
       "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
       "dependencies": {
         "get-port": "^3.1.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/then-request": {
@@ -3330,14 +3271,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
-    },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.35",
@@ -3502,17 +3435,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
-    },
     "node_modules/ws": {
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
@@ -3549,6 +3471,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -3572,6 +3499,15 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zlib": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+      "integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=0.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@govuk-prototype-kit/common-templates": "1.1.1",
     "@ministryofjustice/frontend": "^1.6.6",
     "govuk-frontend": "4.6.0",
-    "govuk-prototype-kit": "13.7.0",
+    "govuk-prototype-kit": "^13.12.2",
     "hmrc-frontend": "5.33.0",
     "jquery": "^3.7.0",
     "radio-button-redirect": "^1.2.0"


### PR DESCRIPTION
Second iteration of the issuing decisions work, links to v1 for personal list.

Content updates, the journey links up and includes:
- Allowed, dismissed and split decisions take the Inspector through the journey and updates the personal list view and the case view
- Invalid journey asks for reasons for invalid and updates the personal list and case view to show the incomplete status

I have also added a v2 for personal list for any further versions of that work (freezing v1 for the UR documentation).