### PR TITLE
Inter font import, override

### DIFF
--- a/app/assets/sass/settings.scss
+++ b/app/assets/sass/settings.scss
@@ -1,0 +1,6 @@
+@import url('https://rsms.me/inter/inter.css');
+$govuk-font-family: 'Inter', sans-serif;
+
+.tableNumbers{
+    font-feature-settings: 'tnum' 1, 'ss01' 1, 'zero' 1;
+}


### PR DESCRIPTION
This change include the addition of a new file in the sass folder to override GDS transport with Inter UI. 